### PR TITLE
Fix mangled type references

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jest": "^25.3.4",
     "eslint-plugin-prettier": "^4.0.0",
-    "flow-bin": "^0.195.0",
+    "flow-bin": "^0.116.1",
     "jest": "^27.4.7",
     "mongodb": "^4.1.3"
   },

--- a/src/nodes/export-declaration.ts
+++ b/src/nodes/export-declaration.ts
@@ -58,7 +58,7 @@ export default class ExportDeclaration extends Node<ExportDeclarationType> {
 
       let result = "";
       if (typeExports.length) {
-        result += generateOutput(`export type`, typeExports);
+        result += generateOutput(`declare export`, typeExports);
       }
       if (valueExports.length) {
         result += generateOutput(`declare export`, valueExports);

--- a/src/nodes/import.ts
+++ b/src/nodes/import.ts
@@ -53,7 +53,9 @@ export default class Import extends Node {
             result += `import${
               this.module === "root" && !isTypeImport ? "" : " type"
             } ${name.text}, {
-            ${elements.map(node => printers.node.printType(node))}
+              ${elements
+                .filter(node => node.name.escapedText !== "type")
+                .map(node => printers.node.printType(node))}
             } from '${this.raw.moduleSpecifier.text}';\n`;
           }
           if (enumElems.length > 0) {
@@ -85,7 +87,9 @@ export default class Import extends Node {
             result += `import${
               this.module === "root" && !isTypeImport ? "" : " type"
             } {
-            ${regularElems.map(node => printers.node.printType(node))}
+              ${regularElems
+                .filter(node => node.name.escapedText !== "type")
+                .map(node => printers.node.printType(node))}
             } from '${this.raw.moduleSpecifier.text}';\n`;
           }
           if (enumElems.length > 0) {

--- a/src/printers/declarations.ts
+++ b/src/printers/declarations.ts
@@ -318,6 +318,9 @@ export const typeReference = (
     }
     name = replaced;
   }
+  // If the type reference name is broken in the format of `"string"$Name`,
+  // strip the prefixed quoted string from "Name":
+  name = name.replace(/^['"]@?[-\w/]+['"]\$(\w+)$/, "$1");
   return (
     printers.relationships.namespaceProp(name) +
     printers.common.generics(node.typeArguments)

--- a/src/printers/relationships.ts
+++ b/src/printers/relationships.ts
@@ -46,6 +46,11 @@ export const importExportSpecifier = (
       node.propertyName,
     )} as ${printers.node.printType(node.name)}`;
   }
+
+  if (node.name.escapedText === "Record") {
+    return "Record";
+  }
+
   return printers.node.printType(node.name);
 };
 


### PR DESCRIPTION
This patch:

1. Applies all patches in `webflow/flow-to-typescript-codemod` to the fork itself
2. Fixes mangled type annotations so that generated flow types not broken
3. Downgrades flow to the version of Flow we are using