### PR TITLE
PDTY-5689 Fix mangled type references

### DIFF
--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -19,3 +19,10 @@ jobs:
       - uses: actions/checkout@v3
       - run: yarn install
       - run: yarn test
+
+  type-check:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v3
+      - run: yarn install
+      - run: yarn type

--- a/src/printers/declarations.ts
+++ b/src/printers/declarations.ts
@@ -318,6 +318,9 @@ export const typeReference = (
     }
     name = replaced;
   }
+  // If the type reference name is broken in the format of `"string"$Name`,
+  // strip the prefixed quoted string from "Name":
+  name = name.replace(/^['"]@?[-\w/]+['"]\$(\w+)$/, "$1");
   return (
     printers.relationships.namespaceProp(name) +
     printers.common.generics(node.typeArguments)


### PR DESCRIPTION
There are times when a type reference is printed prefixed with the declaration path and a dollar sign, so instead of:

```ts
type Foo {
  bar: Baz
}
```

we get:

```ts
type Foo {
  bar: "path/to/baz"$Baz
}
```

The patch here feels like a brute force way of fixing the issue. There's probably something upstream in terms of how things are being transformed in the AST which could better fix this, but this appears to work.