### PR TITLE
PDTY-5707 Omit `typeof` operator when printing references to imported symbols

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "scripts": {
     "prepublishOnly": "npm run compile & npm run type",
     "type": "tsc -p tsconfig.declaration.json",
-    "compile": "babel ./src --extensions '.ts,.tsx,.js' --out-dir lib --delete-dir-on-start --ignore 'src/**/*.spec.ts' --ignore 'src/__tests__/'",
+    "compile": "babel ./src --extensions '.ts,.tsx,.js' --out-dir lib --delete-dir-on-start --ignore 'src/**/*.spec.ts' --ignore 'src/__tests__/' && yarn type",
     "compile:watch": "npm run compile -- -w",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/src/__tests__/declaration-file.spec.ts
+++ b/src/__tests__/declaration-file.spec.ts
@@ -62,3 +62,76 @@ it("should handle re-exporting from across modules", () => {
 
   expect(beautify(result)).toBe(flow);
 });
+
+describe("should handle creating a type from an imported object literal across modules", () => {
+  it("type is keys", () => {
+    const ts = `
+      declare module '@packages/a' {
+        export const foo: {
+          readonly 'a': "A";
+          readonly 'b': "B";
+        };
+      }
+      declare module '@packages/b' {
+        import { foo } from "@packages/a";
+        export type FooKeys = keyof typeof foo;
+      }
+    `;
+
+    const flow = beautify(`
+      declare module "@packages/a" {
+        declare export var foo: {
+          +a: "A",
+          +b: "B",
+          ...
+        };
+      }
+
+      declare module "@packages/b" {
+        import type { foo } from "@packages/a";
+
+        declare export type FooKeys = $Keys<foo>;
+      }
+    `);
+
+    const result = compiler.compileDefinitionString(ts, { quiet: true });
+
+    expect(beautify(result)).toBe(flow);
+  });
+
+  it("type is values", () => {
+    const ts = `
+      declare module '@packages/a' {
+        export const foo: {
+          readonly a: "A";
+        };
+      }
+      declare module '@packages/b' {
+        import { foo } from "@packages/a";
+        export type fooType = (typeof foo)[keyof typeof foo] | null | undefined;
+      }
+    `;
+
+    const flow = beautify(`
+      declare module "@packages/a" {
+        declare export var foo: {
+          +a: "A",
+          ...
+        };
+      }
+
+      declare module "@packages/b" {
+        import type { foo } from "@packages/a";
+
+        declare export type fooType = $ElementType<
+          foo,
+          $Keys<foo>
+        > | null | void;
+      }
+    `);
+
+    const result = compiler.compileDefinitionString(ts, { quiet: true });
+
+    expect(beautify(result)).toBe(flow);
+  });
+});


### PR DESCRIPTION
Context: An object literal (`foo`) is imported from Module A. In Module B, a type (`FooKeys`) is created from the imported object literal's keys or values.

Error: When `flowgen` transforms Module B a FlowParse error is present in the resulting code: "Cannot reference type from a value position".

Cause: When `foo` is used to create `FooKeys` in Module B, `foo` is already a type (NOT A VALUE). Because `foo` was imported into the Flow module declaration with the `type` keyword, so calling `typeof` on it produces the error.

Fix: In TypeScript, when a module imports something, and we encounter the `typeof` operator on it (ie, `TypeQuery`), then do not carry the `typeof` operator over from TypeScript, as it is already a type in Flow.