### PR TITLE
Special case Record<never, never> to {||}

### DIFF
--- a/src/__tests__/__snapshots__/utility-types.spec.ts.snap
+++ b/src/__tests__/__snapshots__/utility-types.spec.ts.snap
@@ -26,36 +26,3 @@ declare type U = \\"a\\";
 declare type C = $Diff<O, { [key: U]: any }>;
 "
 `;
-
-exports[`should handle utility types 1`] = `
-"declare type A = $ReadOnly<{
-  a: number,
-  ...
-}>;
-declare type B = $Rest<
-  {
-    a: number,
-    ...
-  },
-  { ... }
->;
-declare type C = $NonMaybeType<string | null>;
-declare type D = $ReadOnlyArray<string>;
-declare type E = $Call<<R>((...args: any[]) => R) => R, () => string>;
-declare type F = { [key: string]: number, ... };
-declare type G = $ReadOnlySet<number>;
-declare type H = $ReadOnlyMap<string, number>;
-declare type A1<Readonly> = Readonly;
-declare type B1<Partial> = Partial;
-declare type C1<NonNullable> = NonNullable;
-declare type D1<ReadonlyArray> = ReadonlyArray;
-declare type E1<ReturnType> = ReturnType;
-declare type F1<Record> = Record;
-declare type A2<T> = $ReadOnly<T>;
-declare type B2<T> = $Rest<T, { ... }>;
-declare type C2<T> = $NonMaybeType<T>;
-declare type D2<T> = $ReadOnlyArray<T>;
-declare type E2<T> = $Call<<R>((...args: any[]) => R) => R, () => T>;
-declare type F2<T, U> = { [key: T]: U, ... };
-"
-`;

--- a/src/__tests__/utility-types.spec.ts
+++ b/src/__tests__/utility-types.spec.ts
@@ -1,8 +1,7 @@
 import { compiler, beautify } from "..";
 import "../test-matchers";
 
-it("should handle utility types", () => {
-  const ts = `
+const utilityTypes = `
 type A = Readonly<{a: number}>
 type B = Partial<{a: number}>
 type C = NonNullable<string | null>
@@ -11,6 +10,7 @@ type E = ReturnType<() => string>
 type F = Record<string, number>
 type G = ReadonlySet<number>
 type H = ReadonlyMap<string, number>
+type I = Record<never, never>
 
 type A1<Readonly> = Readonly
 type B1<Partial> = Partial
@@ -26,8 +26,82 @@ type D2<T> = ReadonlyArray<T>
 type E2<T> = ReturnType<() => T>
 type F2<T, U> = Record<T, U>
 `;
-  const result = compiler.compileDefinitionString(ts, { quiet: true });
-  expect(beautify(result)).toMatchSnapshot();
+it("should handle utility types", () => {
+  const result = compiler.compileDefinitionString(utilityTypes, {
+    quiet: true,
+  });
+  expect(beautify(result)).toMatchInlineSnapshot(`
+    "declare type A = $ReadOnly<{
+      a: number,
+      ...
+    }>;
+    declare type B = $Rest<
+      {
+        a: number,
+        ...
+      },
+      { ... }
+    >;
+    declare type C = $NonMaybeType<string | null>;
+    declare type D = $ReadOnlyArray<string>;
+    declare type E = $Call<<R>((...args: any[]) => R) => R, () => string>;
+    declare type F = { [key: string]: number, ... };
+    declare type G = $ReadOnlySet<number>;
+    declare type H = $ReadOnlyMap<string, number>;
+    declare type I = { [key: empty]: empty, ... };
+    declare type A1<Readonly> = Readonly;
+    declare type B1<Partial> = Partial;
+    declare type C1<NonNullable> = NonNullable;
+    declare type D1<ReadonlyArray> = ReadonlyArray;
+    declare type E1<ReturnType> = ReturnType;
+    declare type F1<Record> = Record;
+    declare type A2<T> = $ReadOnly<T>;
+    declare type B2<T> = $Rest<T, { ... }>;
+    declare type C2<T> = $NonMaybeType<T>;
+    declare type D2<T> = $ReadOnlyArray<T>;
+    declare type E2<T> = $Call<<R>((...args: any[]) => R) => R, () => T>;
+    declare type F2<T, U> = { [key: T]: U, ... };
+    "
+  `);
+  expect(result).toBeValidFlowTypeDeclarations();
+});
+
+it("should handle utility types in exact mode", () => {
+  const result = compiler.compileDefinitionString(utilityTypes, {
+    quiet: true,
+    inexact: false,
+  });
+  expect(beautify(result)).toMatchInlineSnapshot(`
+    "declare type A = $ReadOnly<{|
+      a: number,
+    |}>;
+    declare type B = $Rest<
+      {|
+        a: number,
+      |},
+      {}
+    >;
+    declare type C = $NonMaybeType<string | null>;
+    declare type D = $ReadOnlyArray<string>;
+    declare type E = $Call<<R>((...args: any[]) => R) => R, () => string>;
+    declare type F = { [key: string]: number };
+    declare type G = $ReadOnlySet<number>;
+    declare type H = $ReadOnlyMap<string, number>;
+    declare type I = {||};
+    declare type A1<Readonly> = Readonly;
+    declare type B1<Partial> = Partial;
+    declare type C1<NonNullable> = NonNullable;
+    declare type D1<ReadonlyArray> = ReadonlyArray;
+    declare type E1<ReturnType> = ReturnType;
+    declare type F1<Record> = Record;
+    declare type A2<T> = $ReadOnly<T>;
+    declare type B2<T> = $Rest<T, {}>;
+    declare type C2<T> = $NonMaybeType<T>;
+    declare type D2<T> = $ReadOnlyArray<T>;
+    declare type E2<T> = $Call<<R>((...args: any[]) => R) => R, () => T>;
+    declare type F2<T, U> = { [key: T]: U };
+    "
+  `);
   expect(result).toBeValidFlowTypeDeclarations();
 });
 

--- a/src/printers/identifiers.ts
+++ b/src/printers/identifiers.ts
@@ -7,12 +7,11 @@ import ts from "typescript";
 
 const Record = ([key, value]: [any, any], isInexact = opts().inexact) => {
   const valueType = printers.node.printType(value);
+  const keyType = printers.node.printType(key);
 
   switch (key.kind) {
     case ts.SyntaxKind.LiteralType:
-      return `{ ${printers.node.printType(key)}: ${valueType}${
-        isInexact ? ", ..." : ""
-      }}`;
+      return `{ ${keyType}: ${valueType}${isInexact ? ", ..." : ""}}`;
     case ts.SyntaxKind.UnionType:
       if (key.types.every(t => t.kind === ts.SyntaxKind.LiteralType)) {
         const fields = key.types.reduce((acc, t) => {
@@ -23,9 +22,10 @@ const Record = ([key, value]: [any, any], isInexact = opts().inexact) => {
       }
     // Fallthrough
     default:
-      return `{[key: ${printers.node.printType(key)}]: ${valueType}${
-        isInexact ? ", ..." : ""
-      }}`;
+      if (keyType === "empty" && valueType === "empty" && !isInexact) {
+        return `{||}`;
+      }
+      return `{[key: ${keyType}]: ${valueType}${isInexact ? ", ..." : ""}}`;
   }
 };
 


### PR DESCRIPTION
When regenerating flow types with `inexact: false`, this change dropped the number of `flow` errors from 32 -> 2.