### PR TITLE
PDTY-5722: Support inline `type` imports

### DIFF
--- a/src/__tests__/__snapshots__/imports.spec.ts.snap
+++ b/src/__tests__/__snapshots__/imports.spec.ts.snap
@@ -32,10 +32,3 @@ exports[`should handle imports inside module 1`] = `
 }
 "
 `;
-
-exports[`should handle type imports 1`] = `
-"import type { GeneratorOptions } from \\"@babel/generator\\";
-import traverse from \\"@babel/traverse\\";
-import type { Visitor as NewVisitor } from \\"@babel/traverse\\";
-"
-`;

--- a/src/__tests__/imports.spec.ts
+++ b/src/__tests__/imports.spec.ts
@@ -42,8 +42,16 @@ it("should handle type imports", () => {
   const ts = `import type { GeneratorOptions } from "@babel/generator";
 import type traverse from "@babel/traverse";
 import type { Visitor as NewVisitor } from "@babel/traverse";
+import { type Visitor, Scope } from "@babel/traverse";
 `;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
-  expect(beautify(result)).toMatchSnapshot();
+  expect(beautify(result)).toMatchInlineSnapshot(`
+    "import type { GeneratorOptions } from \\"@babel/generator\\";
+    import traverse from \\"@babel/traverse\\";
+    import type { Visitor as NewVisitor } from \\"@babel/traverse\\";
+    import { Scope } from \\"@babel/traverse\\";
+    import type { Visitor } from \\"@babel/traverse\\";
+    "
+  `);
   expect(result).not.toBeValidFlowTypeDeclarations(); // cannot-resolve-module
 });


### PR DESCRIPTION
This change updates the `import` printing logic to properly handle inline `type` imports, in addition to the already handled top-level `type` imports.

Prior to this change, the behavior was to attempt to import the `type` keyword itself:

```
import { type, Foo, Bar } from 'place';
```

With this change, we get the more correct:

```
import { Bar } from 'place';
import type { Foo } from 'place';
```

I believe the issue here may be related to the version of the TypeScript parser being used in this repo. Upgrading the version of TypeScript is something we could consider, but may have larger rammifications in this codebase.