### PR TITLE
PDTY-5726: Special-case FlowLang.ObjMap

### DIFF
--- a/src/__tests__/utility-types.spec.ts
+++ b/src/__tests__/utility-types.spec.ts
@@ -25,6 +25,7 @@ type C2<T> = NonNullable<T>
 type D2<T> = ReadonlyArray<T>
 type E2<T> = ReturnType<() => T>
 type F2<T, U> = Record<T, U>
+type J<T, U> = FlowLang.ObjMap<T, U>
 `;
 it("should handle utility types", () => {
   const result = compiler.compileDefinitionString(utilityTypes, {
@@ -61,6 +62,7 @@ it("should handle utility types", () => {
     declare type D2<T> = $ReadOnlyArray<T>;
     declare type E2<T> = $Call<<R>((...args: any[]) => R) => R, () => T>;
     declare type F2<T, U> = { [key: T]: U, ... };
+    declare type J<T, U> = $ObjMap<T, U>;
     "
   `);
   expect(result).toBeValidFlowTypeDeclarations();
@@ -100,6 +102,7 @@ it("should handle utility types in exact mode", () => {
     declare type D2<T> = $ReadOnlyArray<T>;
     declare type E2<T> = $Call<<R>((...args: any[]) => R) => R, () => T>;
     declare type F2<T, U> = { [key: T]: U };
+    declare type J<T, U> = $ObjMap<T, U>;
     "
   `);
   expect(result).toBeValidFlowTypeDeclarations();

--- a/src/printers/node.ts
+++ b/src/printers/node.ts
@@ -80,13 +80,15 @@ type PrintNode =
 
 export function printEntityName(type: ts.EntityName): string {
   if (type.kind === ts.SyntaxKind.QualifiedName) {
-    return (
-      printers.relationships.namespace(
-        type.left.kind === ts.SyntaxKind.Identifier
-          ? type.left.text
-          : printEntityName(type.left),
-      ) + printEntityName(type.right)
-    );
+    const left =
+      type.left.kind === ts.SyntaxKind.Identifier
+        ? type.left.text
+        : printEntityName(type.left);
+    const right = printEntityName(type.right);
+    if (left === "FlowLang" && right === "ObjMap") {
+      return `$ObjMap`;
+    }
+    return printers.relationships.namespace(left) + right;
   } else if (type.kind === ts.SyntaxKind.Identifier) {
     return printers.relationships.namespace(type.text, true);
   } else {


### PR DESCRIPTION
When attempting to convert `packages/utilities/css-properties-type`, there is an instance of `FlowLang.ObjMap` in the generated interface. This is a type generated by the `flow-to-typescript-codemod` to attempt to match `flow`s builtin `$ObjMap` type. As such, we need to special case this type when generating `.js.flow` interface files to return an `$ObjMap` as expected.