### PR TITLE
PDTY-6238: use  for certain Indexed Access Types

### DIFF
--- a/src/__tests__/declaration-file.spec.ts
+++ b/src/__tests__/declaration-file.spec.ts
@@ -123,10 +123,7 @@ describe("should handle creating a type from an imported object literal across m
       declare module "@packages/b" {
         import type { foo } from "@packages/a";
 
-        declare export type fooType = $ElementType<
-          foo,
-          $Keys<foo>
-        > | null | void;
+        declare export type fooType = $Values<foo> | null | void;
       }
     `);
 


### PR DESCRIPTION
In order to support the upgrade to TypeScript 4.9.5 in the monorepo, we want to convert the following:

```
(typeof X)[keyof typeof X]
```
into
```
$Values<X>
```
or
```
$Values<typeof X>
```
depending on whether `X` is a type or a value.

without this, we get `$ElementType<X, $Keys<X>>`, which looks like it should work, but in the version of flow we use seems to be an intersection, rather than a union, meaning that it is completely unrepresentable if `X` has more than a single key.

I believe this change should be completely safe to ship independently of the typescript upgrade. The problem it prevents only seems to manifest after the upgrade, but the solution should be valid regardless.