### PR TITLE
PDTY-6242: mixins => extends

### DIFF
--- a/src/__tests__/__snapshots__/classes.spec.ts.snap
+++ b/src/__tests__/__snapshots__/classes.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`should handle class extends 1`] = `
 "declare class extension {
   getString(): string;
 }
-declare class extender mixins extension {
+declare class extender extends extension {
   getNumber(): number;
 }
 "
@@ -29,7 +29,7 @@ declare interface implementation2 {
 }
 declare class extension {}
 declare class implementor
-  mixins extension
+  extends extension
   implements implementation1, implementation2
 {
   getString(): string;
@@ -41,7 +41,7 @@ declare class implementor
 exports[`should handle static methods ES6 classes 1`] = `
 "declare class Subscribable<T> {}
 declare class Operator<T, R> {}
-declare class Observable<T> mixins Subscribable<T> {
+declare class Observable<T> extends Subscribable<T> {
   create: Function;
   static create: Function;
   lift<R>(operator: Operator<T, R>): Observable<R>;

--- a/src/__tests__/__snapshots__/global-this.spec.ts.snap
+++ b/src/__tests__/__snapshots__/global-this.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`should not crash when getting globalThis in code 1`] = `
 "import * as React from \\"react\\";
-declare export default class MenuStatefulContainer mixins React.Component<> {
+declare export default class MenuStatefulContainer extends React.Component<> {
   handleItemClick: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
   render(): React.Node;
 }

--- a/src/__tests__/__snapshots__/module-identifiers.spec.ts.snap
+++ b/src/__tests__/__snapshots__/module-identifiers.spec.ts.snap
@@ -7,7 +7,7 @@ declare type Props = {
   children: React$Node,
   ...
 };
-declare class Component mixins React.Component<Props> {
+declare class Component extends React.Component<Props> {
   render(): React$Node;
 }
 "

--- a/src/__tests__/__snapshots__/namespaces.spec.ts.snap
+++ b/src/__tests__/__snapshots__/namespaces.spec.ts.snap
@@ -280,7 +280,7 @@ declare class A$B$D<S> {}
 declare var npm$namespace$A$B$C: {|
   N: typeof A$B$C$N,
 |};
-declare class A$B$C$N<A> mixins A$B$D<A> implements A$B$S<A> {
+declare class A$B$C$N<A> extends A$B$D<A> implements A$B$S<A> {
   a: string;
 }
 "

--- a/src/printers/declarations.ts
+++ b/src/printers/declarations.ts
@@ -341,13 +341,13 @@ export const classDeclaration = <T>(
     node.heritageClauses.forEach(clause => {
       clause.types.forEach(classHeritageClause(classMixins, classImplements));
     });
-    const mixinsMessage =
-      classMixins.length > 0 ? `mixins ${classMixins.join(",")}` : "";
+    const extendsMessage =
+      classMixins.length > 0 ? `extends ${classMixins.join(",")}` : "";
     const classImplementsMessage =
       classImplements.length > 0
         ? ` implements ${classImplements.join(",")}`
         : "";
-    heritage += mixinsMessage;
+    heritage += extendsMessage;
     heritage += classImplementsMessage;
   }
 


### PR DESCRIPTION
From what I can tell, `mixins` is a deprecated syntax for inheritance in flow. Searching for `mixins` in the `flow` documentation currently returns 0 results. I believe we should instead be using the "real" syntax: `extends`.
<img width="1920" alt="Screenshot 2023-09-12 at 3 00 46 PM" src="https://github.com/webflow/flowgen/assets/5692947/8663e96f-4ae5-4c0b-b485-9c943feb2caa">
