### PR TITLE
PDTY-6242: Handle Record.Factory -> RecordFactory reverse translation

### DIFF
--- a/src/__tests__/record.spec.ts
+++ b/src/__tests__/record.spec.ts
@@ -47,3 +47,26 @@ it("should handle renamed immutable Record import", () => {
   // throws because `immutable` is not available:
   // expect(result).toBeValidFlowTypeDeclarations();
 });
+
+it("should handle immutable Record.Factory import", () => {
+  const ts = dedent`
+    declare module "@packages/systems/core/records/SyncState" {
+      import { type Record } from 'immutable';
+      export const SyncState: Record.Factory;
+    }
+  `;
+
+  const flow = dedent`
+    declare module "@packages/systems/core/records/SyncState" {
+      import type { Record, RecordFactory } from "immutable";
+
+      declare export var SyncState: RecordFactory;
+    }
+  `;
+
+  const result = compiler.compileDefinitionString(ts, { quiet: true });
+
+  expect(beautify(result)).toBe(beautify(flow));
+  // throws because `immutable` is not available:
+  // expect(result).toBeValidFlowTypeDeclarations();
+});

--- a/src/printers/node.ts
+++ b/src/printers/node.ts
@@ -78,7 +78,11 @@ type PrintNode =
   | ts.SetAccessorDeclaration
   | ts.InferTypeNode;
 
-export function printEntityName(type: ts.EntityName): string {
+export const printEntityName = withEnv<
+  { recordFactory: boolean },
+  [ts.EntityName],
+  void
+>((env, type) => {
   if (type.kind === ts.SyntaxKind.QualifiedName) {
     const left =
       type.left.kind === ts.SyntaxKind.Identifier
@@ -88,13 +92,19 @@ export function printEntityName(type: ts.EntityName): string {
     if (left === "FlowLang" && right === "ObjMap") {
       return `$ObjMap`;
     }
+
+    if (left === "Record" && right === "Factory") {
+      env.recordFactory = true;
+      return "RecordFactory";
+    }
+
     return printers.relationships.namespace(left) + right;
   } else if (type.kind === ts.SyntaxKind.Identifier) {
     return printers.relationships.namespace(type.text, true);
   } else {
     return "";
   }
-}
+});
 
 export function printPropertyAccessExpression(
   type: ts.PropertyAccessExpression | ts.Identifier | ts.PrivateIdentifier,


### PR DESCRIPTION
Earlier today, I wrote some code to translate `RecordFactory` in flow to `Record.Factory` in TypeScript, and update the imports.

This change is essentially the reverse of that one, this time mapping `Record.Factory` in TypeScript back to `RecordFactory` in flow.

I can't wait for this to be over!