### PR TITLE
PDTY-6242: Only insert the RecordFactory import once

### DIFF
--- a/src/__tests__/record.spec.ts
+++ b/src/__tests__/record.spec.ts
@@ -70,3 +70,29 @@ it("should handle immutable Record.Factory import", () => {
   // throws because `immutable` is not available:
   // expect(result).toBeValidFlowTypeDeclarations();
 });
+
+it("should import RecordFactory only once", () => {
+  const ts = dedent`
+    declare module "@packages/systems/core/records/SyncState" {
+      import { type Record } from 'immutable';
+      import { type List } from 'immutable';
+      export const SyncState: Record.Factory;
+    }
+  `;
+
+  const flow = dedent`
+    declare module "@packages/systems/core/records/SyncState" {
+      import type { Record, RecordFactory } from "immutable";
+
+      import type { List } from 'immutable';
+
+      declare export var SyncState: RecordFactory;
+    }
+  `;
+
+  const result = compiler.compileDefinitionString(ts, { quiet: true });
+
+  expect(beautify(result)).toBe(beautify(flow));
+  // throws because `immutable` is not available:
+  // expect(result).toBeValidFlowTypeDeclarations();
+});

--- a/src/nodes/import.ts
+++ b/src/nodes/import.ts
@@ -175,6 +175,7 @@ const getNamedBindings = withEnv<
           ts.factory.createIdentifier("RecordFactory"),
         ),
       );
+      env.recordFactory = false;
     }
     return bindings;
   }


### PR DESCRIPTION
We cannot rely on there being only one `import` statement from the 'immutable' library per file, unfortunately.